### PR TITLE
Fix(response): return response also in case of error

### DIFF
--- a/internal/cmd/buckets.go
+++ b/internal/cmd/buckets.go
@@ -10,7 +10,7 @@ import (
 func ListBuckets(cCtx *cli.Context) error {
 	client := cCtx.Context.Value(OstorClient).(*ostor.Ostor)
 
-	buckets, err := client.GetBuckets("")
+	buckets, _, err := client.GetBuckets("")
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -45,7 +45,7 @@ func ShowStats(cCtx *cli.Context) error {
 		}
 
 		page++
-		items, err := client.List(after)
+		items, _, err := client.List(after)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func ShowStats(cCtx *cli.Context) error {
 
 		for _, obj := range items.Items {
 			// fmt.Println(obj)
-			usage, err := client.ObjectUsage(obj)
+			usage, _, err := client.ObjectUsage(obj)
 			if err != nil {
 				fmt.Println("usage: " + err.Error())
 				os.Exit(2)

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -13,7 +13,7 @@ import (
 func Users(cCtx *cli.Context) error {
 	client := cCtx.Context.Value(OstorClient).(*ostor.Ostor)
 
-	resp, err := client.ListUsers()
+	users, _, err := client.ListUsers()
 	if err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func Users(cCtx *cli.Context) error {
 	tbl := table.New("Email", "ID", "State")
 	tbl.WithHeaderFormatter(headerFmt()).WithFirstColumnFormatter(columnFmt())
 
-	for _, u := range resp.Users {
+	for _, u := range users.Users {
 		tbl.AddRow(u.Email, u.ID, u.State)
 	}
 	tbl.Print()
@@ -79,7 +79,7 @@ func ShowUser(cCtx *cli.Context) error {
 
 	fmt.Println("")
 
-	buckets, err := client.GetBuckets(email)
+	buckets, _, err := client.GetBuckets(email)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -55,8 +55,11 @@ func ShowUser(cCtx *cli.Context) error {
 
 	email := cCtx.String("email")
 
-	user, _, err := client.GetUser(email)
+	user, resp, err := client.GetUser(email)
 	if err != nil {
+		if resp.StatusCode() == 404 {
+			return fmt.Errorf("no user with email %q found", email)
+		}
 		return err
 	}
 
@@ -112,7 +115,7 @@ func CreateKey(cCtx *cli.Context) error {
 
 	email := cCtx.String("email")
 
-	_, err := client.GenerateCredentials(email)
+	_, _, err := client.GenerateCredentials(email)
 	if err != nil {
 		return err
 	}

--- a/pkg/ostor/buckets.go
+++ b/pkg/ostor/buckets.go
@@ -1,9 +1,11 @@
 package ostor
 
+import "github.com/go-resty/resty/v2"
+
 const qBuckets string = "ostor-buckets"
 
-func (o *Ostor) GetBuckets(email string) (*OstorBucketListResponse, error) {
+func (o *Ostor) GetBuckets(email string) (*OstorBucketListResponse, *resty.Response, error) {
 	var buckets *OstorBucketListResponse
-	_, err := o.get(qBuckets, map[string]string{"emailAddress": email}, &buckets)
-	return buckets, err
+	resp, err := o.get(qBuckets, map[string]string{"emailAddress": email}, &buckets)
+	return buckets, resp, err
 }

--- a/pkg/ostor/key.go
+++ b/pkg/ostor/key.go
@@ -2,10 +2,10 @@ package ostor
 
 import "github.com/go-resty/resty/v2"
 
-func (o *Ostor) GenerateCredentials(email string) (*OstorCreateUserResponse, error) {
+func (o *Ostor) GenerateCredentials(email string) (*OstorCreateUserResponse, *resty.Response, error) {
 	var user *OstorCreateUserResponse
-	_, err := o.post(qUsers, qUsers+"&emailAddress="+email+"&genKey", user)
-	return user, err
+	resp, err := o.post(qUsers, qUsers+"&emailAddress="+email+"&genKey", user)
+	return user, resp, err
 }
 
 func (o *Ostor) RevokeKey(email, accessKeyID string) (*resty.Response, error) {

--- a/pkg/ostor/ostor.go
+++ b/pkg/ostor/ostor.go
@@ -103,16 +103,16 @@ func (o *Ostor) request(req *resty.Request, cmd, method, url string) (*resty.Res
 		// fmt.Printf("%v", res.Request)
 		// b, _ := io.ReadAll(res.RawBody())
 		// fmt.Println(b)
-		return nil, fmt.Errorf("request failed: %s", err)
+		return res, fmt.Errorf("request failed: %s", err)
 	}
 
 	if res.IsError() {
 		headers := res.Header()
 		if headers.Get("X-Amz-Err-Message") != "" {
-			return nil, fmt.Errorf("request failed: %s", headers.Get("X-Amz-Err-Message"))
+			return res, fmt.Errorf("request failed: %s", headers.Get("X-Amz-Err-Message"))
 		}
 
-		return nil, fmt.Errorf("unable to make request: %d", res.StatusCode())
+		return res, fmt.Errorf("unable to make request: %d", res.StatusCode())
 	}
 
 	return res, nil

--- a/pkg/ostor/stats.go
+++ b/pkg/ostor/stats.go
@@ -1,8 +1,10 @@
 package ostor
 
+import "github.com/go-resty/resty/v2"
+
 const qStats string = "ostor-usage"
 
-func (o *Ostor) List(after *string) (*OStorResponse, error) {
+func (o *Ostor) List(after *string) (*OStorResponse, *resty.Response, error) {
 	var stats *OStorResponse
 
 	queryString := map[string]string{}
@@ -16,21 +18,13 @@ func (o *Ostor) List(after *string) (*OStorResponse, error) {
 	// - limit cannot be used with pagination (unless we implement other logic)
 	// queryString["limit"] = strconv.Itoa(710)
 
-	_, err := o.get(qStats, queryString, &stats)
-	if err != nil {
-		return stats, err
-	}
-
-	return stats, err
+	resp, err := o.get(qStats, queryString, &stats)
+	return stats, resp, err
 }
 
-func (o *Ostor) ObjectUsage(object string) (*OStorObjectUsageResponse, error) {
+func (o *Ostor) ObjectUsage(object string) (*OStorObjectUsageResponse, *resty.Response, error) {
 	var usage *OStorObjectUsageResponse
 
-	_, err := o.get(qStats, map[string]string{"obj": object}, &usage)
-	if err != nil {
-		return usage, err
-	}
-
-	return usage, err
+	resp, err := o.get(qStats, map[string]string{"obj": object}, &usage)
+	return usage, resp, err
 }

--- a/pkg/ostor/user.go
+++ b/pkg/ostor/user.go
@@ -11,10 +11,10 @@ func (o *Ostor) CreateUser(email string) (*OstorCreateUserResponse, *resty.Respo
 	return user, resp, err
 }
 
-func (o *Ostor) ListUsers() (*OstorUsersListResponse, error) {
+func (o *Ostor) ListUsers() (*OstorUsersListResponse, *resty.Response, error) {
 	var users *OstorUsersListResponse
-	_, err := o.get(qUsers, map[string]string{}, &users)
-	return users, err
+	resp, err := o.get(qUsers, map[string]string{}, &users)
+	return users, resp, err
 }
 
 func (o *Ostor) GetUser(email string) (*OstorUser, *resty.Response, error) {


### PR DESCRIPTION
In the previous release, I introduced the response as a return value
on various function calls. In case of error, the response was nil
which leads to a nil pointer exception in other code.

This commit ensures that the response object is always returned.
