### PR TITLE
Fix(ostor): int(32) overflow

### DIFF
--- a/cmd/tenant-usage/main.go
+++ b/cmd/tenant-usage/main.go
@@ -73,7 +73,7 @@ func main() {
 						app.Name,
 						app.Type,
 						usages.Name,
-						utils.PrettyByteSize(int(math.Round(usages.AbsoluteValue))),
+						utils.PrettyByteSize(int64(math.Round(usages.AbsoluteValue))),
 					)
 				}
 			}

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -13,12 +13,12 @@ import (
 )
 
 type stat struct {
-	Put        int
-	Get        int
-	List       int
-	Other      int
-	Downloaded int
-	Uploaded   int
+	Put        int64
+	Get        int64
+	List       int64
+	Other      int64
+	Downloaded int64
+	Uploaded   int64
 }
 
 // show stats is really expensive, it will (attempt to) crawl the entire `?ostor-usage` endpoint

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -29,7 +29,7 @@ func Users(cCtx *cli.Context) error {
 
 	for _, u := range users.Users {
 		if cCtx.Bool("usage") {
-			tbl.AddRow(u.Email, u.ID, u.State, utils.PrettyByteSize(int(u.Space.Current)))
+			tbl.AddRow(u.Email, u.ID, u.State, utils.PrettyByteSize(u.Space.Current))
 		} else {
 			tbl.AddRow(u.Email, u.ID, u.State)
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,12 +6,12 @@ import (
 
 // credit:
 // https://gist.github.com/anikitenko/b41206a49727b83a530142c76b1cb82d?permalink_comment_id=4467913#gistcomment-4467913
-func PrettyByteSize(bytes int) string {
+func PrettyByteSize(bytes int64) string {
 	const (
-		KB = 1024
-		MB = KB * 1024
-		GB = MB * 1024
-		TB = GB * 1024
+		KB int64 = 1024
+		MB       = KB * 1024
+		GB       = MB * 1024
+		TB       = GB * 1024
 	)
 
 	switch {

--- a/pkg/ostor/types.go
+++ b/pkg/ostor/types.go
@@ -78,15 +78,15 @@ type ItemKey struct {
 }
 
 type ItemCountersOps struct {
-	Put   int `json:"put"`
-	Get   int `json:"get"`
-	List  int `json:"list"`
-	Other int `json:"other"`
+	Put   int64 `json:"put"`
+	Get   int64 `json:"get"`
+	List  int64 `json:"list"`
+	Other int64 `json:"other"`
 }
 
 type ItemCountersNet struct {
-	Uploaded   int `json:"uploaded"`
-	Downloaded int `json:"downloaded"`
+	Uploaded   int64 `json:"uploaded"`
+	Downloaded int64 `json:"downloaded"`
 }
 
 // { "Users":[
@@ -156,10 +156,10 @@ type OstorUserLimits struct {
 //         }  },
 
 type BucketSize struct {
-	Current   int `json:"current"`
-	HMax      int `json:"hmax"`
-	HIntegral int `json:"h_integral"`
-	LastTS    int `json:"last_ts"`
+	Current   int64 `json:"current"`
+	HMax      int64 `json:"hmax"`
+	HIntegral int64 `json:"h_integral"`
+	LastTS    int64 `json:"last_ts"`
 }
 
 type Bucket struct {


### PR DESCRIPTION
- convert all int to int64 to avoid overflows
- mostly impacts the bytes to MB, GB, TB etc conversion
- also set all counters as int64 in case they return larger values
